### PR TITLE
After install, the getAvailableTemplates() method , scandir find .php…

### DIFF
--- a/ps_emailsmanager.php
+++ b/ps_emailsmanager.php
@@ -841,8 +841,8 @@ class Ps_EmailsManager extends Module
             return $templates;
         }
 
-        //remove '.' and '..' from array
-        $templatesDir = array_diff($templatesDir, array('.', '..'));
+        //remove '.', '..' and 'index.php' from array
+        $templatesDir = array_diff($templatesDir, array('.', '..', 'index.php'));
 
         foreach ($templatesDir as $tpl) {
             $settings = $uploadDir.$tpl.DIRECTORY_SEPARATOR.'settings.json';


### PR DESCRIPTION
… files

When running scandir, the method getAvailableTemplates() get not only . and .. files, but also index.php
This results in a warning about open_base_dir restrictions if set when running the following get_file_contents()

Warning à la ligne 41 du fichier /var/www/PRESTASHOP/override/modules/ps_emailsmanager/ps_emailsmanager.php
[2] file_exists(): open_basedir restriction in effect. File(/var/www/PRESTASHOP/modules/ps_emailsmanager/imports/index.php/settings.json) is not within the allowed path(s): (/var/www/PRESTASHOP:/tmp)